### PR TITLE
Pass object instead of string to stream for mssql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.4
+- [hotfix] ensure that JSON object is passed to stream instead of string
+
 ## 0.3.3
 - [hotfix] ensure that objectMode is set with proper casing for Node v8.x and above when streaming MS SQL records
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "picture": "picture.png",
   "source": "sql",
   "logo": "logo.png",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "tags": [
     "incoming",
     "oneColumn",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hull-sql",
   "description": "Install SQL connector on your Hull dashboard",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "homepage": "https://github.com/hull-ships/hull-sql",
   "license": "MIT",
   "main": "dist/ship.js",

--- a/server/lib/adapters/mssql.js
+++ b/server/lib/adapters/mssql.js
@@ -241,7 +241,7 @@ export function streamQuery(client, query, options = {}) {
           _.forEach(columns, (column) => {
             row[column.metadata.colName] = column.value;
           });
-          stream.push(JSON.stringify(row));
+          stream.push(row);
         });
 
         request.on("done", (rowCount) => { // eslint-disable-line consistent-return


### PR DESCRIPTION
### Changes

- ensure that JSON object is passed to stream instead of string