### PR TITLE
Group job import chunks with `import_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.7
+- add job_id and part_number to import job API
+
 ## 0.3.6
 - [hotfix] Fix reporting of import size
 - remove options to sync every minute

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "picture": "picture.png",
   "source": "sql",
   "logo": "logo.png",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "tags": [
     "incoming",
     "oneColumn",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hull-sql",
   "description": "Install SQL connector on your Hull dashboard",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "homepage": "https://github.com/hull-ships/hull-sql",
   "license": "MIT",
   "main": "dist/ship.js",

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -241,8 +241,8 @@ export default class SyncAgent {
   sync(stream, started_sync_at) {
     let processed = 0;
     let last_updated_at;
-    const jobId = _.get(this, "job.id", uuid());
-    const importId = uuid();
+    const jobId = _.get(this, "job.id", uuid()); // ID of the job chunk
+    const importId = uuid(); // ID of the whole job
 
     const transform = map({ objectMode: true }, (record) => {
       const data = {}; // data formated to be sent to hull
@@ -400,7 +400,7 @@ export default class SyncAgent {
     });
   }
 
-  startImportJob(url, partNumber, size, import_id) {
+  startImportJob(url, partNumber, size, importId) {
     const { overwrite } = this.ship.private_settings;
     const params = {
       url,
@@ -412,7 +412,7 @@ export default class SyncAgent {
       schedule_at: moment().add(this.importDelay + (2 * partNumber), "minutes").toISOString(),
       stats: { size },
       size,
-      import_id,
+      import_id: importId,
       part_number: partNumber
     };
 

--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -242,6 +242,7 @@ export default class SyncAgent {
     let processed = 0;
     let last_updated_at;
     const jobId = _.get(this, "job.id", uuid());
+    const importId = uuid();
 
     const transform = map({ objectMode: true }, (record) => {
       const data = {}; // data formated to be sent to hull
@@ -344,7 +345,7 @@ export default class SyncAgent {
         return (() => {
           this.hull.logger.info("incoming.job.progress", { jobName: "sync", stepName: "upload", progress: partNumber, size, type: this.import_type });
           if (size > 0) {
-            return this.startImportJob(url, partNumber, size, jobId);
+            return this.startImportJob(url, partNumber, size, importId);
           }
           return false;
         })()
@@ -399,7 +400,7 @@ export default class SyncAgent {
     });
   }
 
-  startImportJob(url, partNumber, size, jobId) {
+  startImportJob(url, partNumber, size, import_id) {
     const { overwrite } = this.ship.private_settings;
     const params = {
       url,
@@ -411,7 +412,7 @@ export default class SyncAgent {
       schedule_at: moment().add(this.importDelay + (2 * partNumber), "minutes").toISOString(),
       stats: { size },
       size,
-      job_id: jobId,
+      import_id,
       part_number: partNumber
     };
 


### PR DESCRIPTION
add `import_id` and `part_number` to the import job API to group jobs chunk in the Dashboard.