### PR TITLE
supressing possible error thrown by status message

### DIFF
--- a/server/lib/sync-agent.js
+++ b/server/lib/sync-agent.js
@@ -594,6 +594,15 @@ export default class SyncAgent {
         this.hull.put("app/status", {
           status: "error",
           messages: [_.get(err, "message", err)]
+        }).catch(statusError => {
+          // we think this error is what's causing the app to crash, supress it for now
+          this.hull.logger.error("incoming.job.error", {
+            jobName: "sync",
+            errors: _.get(statusError, "message", err),
+            hull_summary: "logging caught status message",
+            type: this.import_type
+          });
+          return Promise.resolve();
         });
         reject(err);
       });


### PR DESCRIPTION
We're having issues where we aren't catching an error that's causing the connector to crash, this should tell us if it's this particular promise that's the issue (I think it is).  It may not be the final code, but it will determine what the cause is.